### PR TITLE
Feature/new benchmarkresult attribute

### DIFF
--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -161,6 +161,7 @@ class BenchmarkResult:
     github: Dict[str, str] = field(
         default_factory=_machine_info.gh_commit_info_from_env
     )
+    query_plan: str = None
 
     def __post_init__(self) -> None:
         self._maybe_set_run_name()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       FLASK_APP: "conbench"
       FLASK_ENV: "development"
       FLASK_DEBUG: "true"
-      REGISTRATION_KEY: "innocent-registration-key"
+      REGISTRATION_KEY: "test"
       SECRET_KEY: "Person, woman, man, camera, TV"
       # Default log level is INFO, change to DEBUG as needed.
       # CONBENCH_LOG_LEVEL_STDERR: DEBUG

--- a/systest_mimic/BenchmarkResults.json
+++ b/systest_mimic/BenchmarkResults.json
@@ -1,6 +1,6 @@
 [
     {
-        "query name": "Manufacturing",
-        "time": 18050844041
+        "query name": "TestQueryName",
+        "time": 22222222222
     }
 ]

--- a/systest_mimic/BenchmarkResults.json
+++ b/systest_mimic/BenchmarkResults.json
@@ -1,0 +1,6 @@
+[
+    {
+        "query name": "Manufacturing",
+        "time": 18050844041
+    }
+]

--- a/systest_mimic/README.md
+++ b/systest_mimic/README.md
@@ -1,0 +1,18 @@
+# Systest Mimic
+
+Following the footsteps of `nebula/scripts/benchmarking/benchmark.py`,  
+the `systest_mimic/` directory contains all files necessary to send benchmarks (and soon, query plans) to the Conbench server.
+
+To avoid clutter, all data and scripts **not natively belonging to Conbench** should be stored here.
+
+## Contents
+
+- `benchmark.py` - Script to send benchmark data to the server  
+- `BenchmarkResult.json` - Example benchmark file, for debugging purposes only one entry
+- `response.json` - Full benchmark with metadata, as sent to the server
+- `.env` - Args for testing, important: CONBENCH_URL, CONBENCH_EMAIL, CONBENCH_PASSWORD, CONBENCH_RUN_REASON
+
+## Additional Requirements
+
+- `pip install -e benchadapt/python/` - local install
+- `pip install python-dotenv` - for easy .env loading

--- a/systest_mimic/benchmark.py
+++ b/systest_mimic/benchmark.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+import time
+import os
+import logging
+from typing import List, Any
+
+from dotenv import load_dotenv
+load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '.env'))
+
+log = logging.getLogger(__name__)
+
+from benchadapt import BenchmarkResult
+from benchadapt.adapters import BenchmarkAdapter
+
+import argparse
+
+
+class SystestAdapter(BenchmarkAdapter):
+    """
+    An adapter to read in Systest benchmark results, transform them to the correct schema and upload them to conbench
+    """
+    systest_working_dir: str
+    result_fields_override: dict[str, Any] = None,
+    result_fields_append: dict[str, Any] = None,
+
+    def __init__(
+            self,
+            systest_working_dir: str,
+            result_fields_override: dict[str, Any] = None,
+            result_fields_append: dict[str, Any] = None,
+    ) -> None:
+        super().__init__(
+            command=[],
+            result_fields_append=result_fields_append,
+            result_fields_override=result_fields_override)
+        self.systest_working_dir = systest_working_dir
+        self.results = self.transform_results()
+
+    def _transform_results(self) -> List[BenchmarkResult]:
+        with open(self.systest_working_dir + "/BenchmarkResults.json", "r") as f:
+            raw_results = json.load(f)
+
+        benchmarkResults = []
+
+        for result in raw_results:
+            benchmarkResults.append(BenchmarkResult(
+                stats={
+                    "data": [result["time"]],
+                    "unit": "ns"
+                },
+                context={"benchmark_language": "systest"},
+                tags={"name": result["query name"]},
+                github={"repository": "https://github.com/fake/fake"}, #TODO: might not be needed
+                #query_plan="BLA_TEST_TEST_BLA", # TODO: add attribute to conbench
+            ))
+
+        return benchmarkResults
+
+
+systest_adapter = SystestAdapter(
+    systest_working_dir=os.path.join(os.path.dirname(__file__)),
+    result_fields_override={"run_reason": os.getenv("CONBENCH_RUN_REASON")},
+)
+
+# reads the message send to the server
+message = systest_adapter.post_results()
+if message:
+    print(message) #prints the message send to the server for debugging purposes

--- a/systest_mimic/benchmark.py
+++ b/systest_mimic/benchmark.py
@@ -52,7 +52,7 @@ class SystestAdapter(BenchmarkAdapter):
                 context={"benchmark_language": "systest"},
                 tags={"name": result["query name"]},
                 github={"repository": "https://github.com/fake/fake"}, #TODO: might not be needed
-                #query_plan="BLA_TEST_TEST_BLA", # TODO: add attribute to conbench
+                query_plan="SECOND_TEST", # TODO: add attribute to conbench
             ))
 
         return benchmarkResults

--- a/systest_mimic/response.json
+++ b/systest_mimic/response.json
@@ -1,0 +1,72 @@
+[
+   {
+      "batch_id":"e5e38d2e1cfa4273b78ad4338d1f139b",
+      "change_annotations":{
+
+      },
+      "commit":"None",
+      "commit_repo_url":"https://github.com/fake/fake",
+      "error":"None",
+      "hardware":{
+         "architecture_name":"x86_64",
+         "cpu_core_count":0,
+         "cpu_frequency_max_hz":5137000000,
+         "cpu_l1d_cache_bytes":262144,
+         "cpu_l1i_cache_bytes":262144,
+         "cpu_l2_cache_bytes":8388608,
+         "cpu_l3_cache_bytes":16777216,
+         "cpu_model_name":"AMD Ryzen 7 7840HS with Radeon 780M Graphics",
+         "cpu_thread_count":16,
+         "gpu_count":0,
+         "gpu_product_names":[
+
+         ],
+         "id":"0683c992c1e870048000ab8fef95ef01",
+         "kernel_name":"6.14.6-arch1-1",
+         "memory_bytes":27917287424,
+         "name":"user",
+         "os_name":"Linux",
+         "os_version":"6.14.6-arch1-1-x86_64-with-glibc2.41",
+         "type":"machine"
+      },
+      "history_fingerprint":"7ea46781fb4fe5dfd69c6e71e9218633",
+      "id":"0683d7564d9271268000ba8612faeedf",
+      "links":{
+         "context":"http://localhost:5000/api/contexts/0683c992c1c67dbb80007b5b2f36275c/",
+         "info":"http://localhost:5000/api/info/0683c992c1d0775580004c93eb3f41cc/",
+         "list":"http://localhost:5000/api/benchmarks/",
+         "run":"http://localhost:5000/api/runs/774fac980cb24242bdc8a3e31acf5c98/",
+         "self":"http://localhost:5000/api/benchmarks/0683d7564d9271268000ba8612faeedf/"
+      },
+      "optional_benchmark_info":"None",
+      "run_id":"774fac980cb24242bdc8a3e31acf5c98",
+      "run_reason":"local test run",
+      "run_tags":{
+
+      },
+      "stats":{
+         "data":[
+            18050844041.0
+         ],
+         "iqr":"None",
+         "iterations":"None",
+         "max":"None",
+         "mean":18050844041.0,
+         "median":"None",
+         "min":"None",
+         "q1":"None",
+         "q3":"None",
+         "stdev":"None",
+         "time_unit":"None",
+         "times":[
+
+         ],
+         "unit":"ns"
+      },
+      "tags":{
+         "name":"Manufacturing"
+      },
+      "timestamp":"2025-06-02T09:56:52Z",
+      "validation":"None"
+   }
+]


### PR DESCRIPTION
Added query_plan string attribute to Conbench in preparation for the actual JSON and to do some testing.
As seen in systest_mimic/benchmark.py we can simply add the query_plan attribute to the BenchmarkResult in the same way we would stats or tags, etc.
(Keep in mind that it is only a string for now, this will change once the JSON structure is final.)