### PR TITLE
added html file for query graph

### DIFF
--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -235,6 +235,7 @@
             </li>
           {% endfor %}
         {% endif %}
+        {% include "query-plan.html" %}
       </ul>
     </div>
     <div class="col-md-6">

--- a/conbench/templates/query-plan.html
+++ b/conbench/templates/query-plan.html
@@ -1,0 +1,5 @@
+<ul class="list-group">
+    <li class="list-group-item list-group-item-primary">
+        {{ benchmark.query_plan }}
+    </li>
+</ul>

--- a/systest_mimic/benchmark.py
+++ b/systest_mimic/benchmark.py
@@ -52,7 +52,7 @@ class SystestAdapter(BenchmarkAdapter):
                 context={"benchmark_language": "systest"},
                 tags={"name": result["query name"]},
                 github={"repository": "https://github.com/fake/fake"}, #TODO: might not be needed
-                query_plan="SECOND_TEST", # TODO: add attribute to conbench
+                query_plan="QUERY_PLAN",
             ))
 
         return benchmarkResults


### PR DESCRIPTION
I added the file query_plan.html to the templates directory so we can put all of our graph code in there.
Then we simply have to use include where ever it's needed.
I also added an example to the query_plan.html file of how to use the query_plan variable.
This variable is currently only a string but will be full of graph data in the future.